### PR TITLE
feat(generator): use stdlib maps

### DIFF
--- a/internal/generator/generate.go
+++ b/internal/generator/generate.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"maps"
 	"net/url"
 	"os"
 	"path"
@@ -42,7 +43,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/mitchellh/hashstructure"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -216,7 +216,7 @@ func getReleasesTags(repo *git.Repository) ([]*plumbing.Reference, error) {
 	}
 
 	// Sort
-	versions := maps.Keys(versionToRef)
+	versions := slices.Collect(maps.Keys(versionToRef))
 	semver.Sort(versions)
 
 	out := make([]*plumbing.Reference, 0, len(versions))

--- a/internal/generator/go.mod
+++ b/internal/generator/go.mod
@@ -1,6 +1,6 @@
 module generator
 
-go 1.21
+go 1.24
 
 require (
 	github.com/coreos/go-semver v0.3.1
@@ -8,7 +8,6 @@ require (
 	github.com/elastic/go-licenser v0.4.2
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/mitchellh/hashstructure v1.1.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	gopkg.in/yaml.v3 v3.0.1
 )
 


### PR DESCRIPTION
Replace golang.org/x/exp/maps with stdlib maps that was added in Go 1.23.