### PR TITLE
feat: add Fields function to get all fields

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -38,11 +38,35 @@ var (
 // Field represents an ECS field.
 type Field = version.Field
 
-// Lookup an ECS field definition. If ecsVersion is empty then the latest version
-// is used. You may specify a partial version specifier (e.g. '8', '8.1'), and
-// the latest matching version will be searched. The returned Field should not be
-// modified.
+// Lookup an ECS field definition.
+// If ecsVersion is empty, Lookup uses the latest ECS version's fields.
+// You may specify a partial version specifier (e.g. '8', '8.1'), and Lookup will
+// search for the latest matching version.
+// Do not modify the returned Field.
+// Lookup returns ErrInvalidVersion if the version string is invalid, or
+// ErrVersionNotFound if no matching version exists.
 func Lookup(fieldName, ecsVersion string) (*Field, error) {
+	fields, err := Fields(ecsVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup the field by name.
+	if f, found := fields[fieldName]; found {
+		return f, nil
+	}
+
+	return nil, ErrFieldNotFound
+}
+
+// Fields returns a map of ECS field definitions for the specified version.
+// If ecsVersion is empty, Fields returns the latest ECS version's fields.
+// You may specify a partial version specifier (e.g. '8', '8.1'), and Fields
+// will search for the latest matching version.
+// Do not modify the returned map or its values.
+// Fields returns ErrInvalidVersion if the version string is invalid, or
+// ErrVersionNotFound if no matching version exists.
+func Fields(ecsVersion string) (map[string]*Field, error) {
 	// Normalize the version.
 	semVer := strings.TrimPrefix(ecsVersion, "v")
 	if ecsVersion != semVer && semVer == "" {
@@ -61,10 +85,5 @@ func Lookup(fieldName, ecsVersion string) (*Field, error) {
 		}
 	}
 
-	// Lookup the field by name.
-	if f, found := fields[fieldName]; found {
-		return f, nil
-	}
-
-	return nil, ErrFieldNotFound
+	return fields, nil
 }

--- a/ecs_test.go
+++ b/ecs_test.go
@@ -20,42 +20,152 @@ package ecs
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
 func TestLookup(t *testing.T) {
 	testCases := []struct {
-		Field   string
-		Version string
-		Fail    bool
+		name    string
+		field   string
+		version string
+		wantErr error
 	}{
-		{Field: "labels", Version: "v8.9"}, // Leading 'v' is tolerated.
-
-		{Field: "labels", Version: "8"},
-		{Field: "labels", Version: "8.9"},
-		{Field: "labels", Version: "8.9.0"},
-
-		{Field: "labels", Version: "v8.9.1", Fail: true}, // Version does not exists.
-
-		{Field: "labels", Version: ""}, // No version should use the latest.
-		{Field: "labels", Version: "v", Fail: true},
+		{
+			name:    "valid field with v prefix version",
+			field:   "labels",
+			version: "v8.9",
+			wantErr: nil,
+		},
+		{
+			name:    "valid field with partial version",
+			field:   "labels",
+			version: "8",
+			wantErr: nil,
+		},
+		{
+			name:    "valid field with full version",
+			field:   "labels",
+			version: "8.9",
+			wantErr: nil,
+		},
+		{
+			name:    "valid field with patch version",
+			field:   "labels",
+			version: "8.9.0",
+			wantErr: nil,
+		},
+		{
+			name:    "valid field with empty version",
+			field:   "labels",
+			version: "",
+			wantErr: nil,
+		},
+		{
+			name:    "nonexistent version",
+			field:   "labels",
+			version: "v8.9.1",
+			wantErr: ErrVersionNotFound,
+		},
+		{
+			name:    "invalid version - only v",
+			field:   "labels",
+			version: "v",
+			wantErr: ErrInvalidVersion,
+		},
+		{
+			name:    "nonexistent field",
+			field:   "nonexistent.field",
+			version: "8.9",
+			wantErr: ErrFieldNotFound,
+		},
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.Version, func(t *testing.T) {
-			f, err := Lookup(tc.Field, tc.Version)
-			if tc.Fail {
-				if err == nil {
-					t.Fatal("expected an error, but got nil")
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := Lookup(tc.field, tc.version)
+
+			if tc.wantErr != nil {
+				if err != tc.wantErr { //nolint:errorlint // These errors are never wrapped.
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
 				}
 				return
 			}
+
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("unexpected error: %v", err)
 			}
+
 			if f == nil {
 				t.Fatal("expected non-nil field, but got nil")
+			}
+		})
+	}
+}
+
+func TestFields(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+		wantErr error
+	}{
+		{
+			name:    "empty version returns latest",
+			version: "",
+			wantErr: nil,
+		},
+		{
+			name:    "valid version with v prefix",
+			version: "v8.9",
+			wantErr: nil,
+		},
+		{
+			name:    "valid version without prefix",
+			version: "8.9",
+			wantErr: nil,
+		},
+		{
+			name:    "partial version",
+			version: "8",
+			wantErr: nil,
+		},
+		{
+			name:    "invalid version - only v",
+			version: "v",
+			wantErr: ErrInvalidVersion,
+		},
+		{
+			name:    "nonexistent version",
+			version: "99.99.99",
+			wantErr: ErrVersionNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields, err := Fields(tc.version)
+
+			if tc.wantErr != nil {
+				if err != tc.wantErr { //nolint:errorlint // These errors are never wrapped.
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if fields == nil {
+				t.Fatal("expected non-nil fields map")
+			}
+
+			if len(fields) == 0 {
+				t.Fatal("expected non-empty fields map")
+			}
+
+			if _, exists := fields["labels"]; !exists {
+				t.Error("expected 'labels' field to exist in fields map")
 			}
 		})
 	}
@@ -64,6 +174,15 @@ func TestLookup(t *testing.T) {
 func BenchmarkLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := Lookup("labels", "v8")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFields(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := Fields("v8")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -85,4 +204,25 @@ func ExampleLookup() {
 	//   "array": false,
 	//   "description": "Operating system name, without the version."
 	// }
+}
+
+func ExampleFields() {
+	fields, err := Fields("8.10")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var hostFields int
+	for name := range fields {
+		if strings.HasPrefix(name, "host.") {
+			hostFields++
+		}
+	}
+
+	fmt.Println("Total fields in ECS 8.10:", len(fields))
+	fmt.Println("Total host fields:", hostFields)
+
+	// Output: Total fields in ECS 8.10: 1659
+	// Total host fields: 42
 }


### PR DESCRIPTION
Add Fields function to retrieve all ECS field definitions for a specified version. The function handles version normalization and delegates field lookup operations.

Update Lookup function to use Fields internally for better code reuse.

Include unit tests covering version validation scenarios and field lookup behavior. Add example documentation demonstrating usage patterns.